### PR TITLE
blueprint: Upgrade etcd version to 3.3

### DIFF
--- a/etcd.js
+++ b/etcd.js
@@ -3,7 +3,7 @@ const { Container, allowTraffic } = require('kelda');
 function Etcd(n) {
   this.containers = [];
   for (let i = 0; i < n; i += 1) {
-    this.containers.push(new Container('etcd', 'quay.io/coreos/etcd:v3.0.2'));
+    this.containers.push(new Container('etcd', 'quay.io/coreos/etcd:v3.3'));
   }
 
   const initialCluster = this.containers.map((c) => {
@@ -15,7 +15,7 @@ function Etcd(n) {
   this.containers.forEach((c) => {
     const host = c.getHostname();
     c.setEnv('ETCD_NAME', host);
-    c.setEnv('ETCD_LISTEN_PEER_URLS', `http://${host}:2380`);
+    c.setEnv('ETCD_LISTEN_PEER_URLS', 'http://0.0.0.0:2380');
     c.setEnv('ETCD_LISTEN_CLIENT_URLS', 'http://0.0.0.0:2379');
     c.setEnv('ETCD_INITIAL_ADVERTISE_PEER_URLS', `http://${host}:2380`);
     c.setEnv('ETCD_INITIAL_CLUSTER', initialClusterStr);


### PR DESCRIPTION
Version 3.0.2 doesn't work with the master version of the Kelda
deployment engine because the etcd binary was compiled with Go version
1.7.5. Go 1.7.5 did not properly handle a value of zero for the resolv.conf
`ndots:n` option (https://github.com/golang/go/issues/15419). Handling
the zero value is important because Kelda hostnames don't have a TLD, so
their "ndots" is zero.  Treating `ndots:0` as `ndots:1` results in
applications being unable to resolve hosts via DNS since the DNS search
domains get used.

Note that this problem isn't present (i.e. v3.0.2 works) in the upcoming
Kubernetes rewrite of the deployment engine because the resolv.conf
won't have any search domains. Right now, the container's resolv.conf
has search domains because the Docker network plugin automatically
copies the domains from the host's resolv.conf.