### PR TITLE
blueprint: Remove use of deprecated functions

### DIFF
--- a/etcd.js
+++ b/etcd.js
@@ -17,13 +17,15 @@ function Etcd(n) {
 
   this.containers.forEach((c) => {
     const host = c.getHostname();
-    c.setEnv('ETCD_NAME', host);
-    c.setEnv('ETCD_LISTEN_PEER_URLS', 'http://0.0.0.0:2380');
-    c.setEnv('ETCD_LISTEN_CLIENT_URLS', 'http://0.0.0.0:2379');
-    c.setEnv('ETCD_INITIAL_ADVERTISE_PEER_URLS', `http://${host}:2380`);
-    c.setEnv('ETCD_INITIAL_CLUSTER', initialClusterStr);
-    c.setEnv('ETCD_INITIAL_CLUSTER_STATE', 'new');
-    c.setEnv('ETCD_ADVERTISE_CLIENT_URLS', `http://${host}:2379`);
+    /* eslint-disable no-param-reassign */
+    c.env.ETCD_NAME = host;
+    c.env.ETCD_LISTEN_PEER_URLS = 'http://0.0.0.0:2380';
+    c.env.ETCD_LISTEN_CLIENT_URLS = 'http://0.0.0.0:2379';
+    c.env.ETCD_INITIAL_ADVERTISE_PEER_URLS = `http://${host}:2380`;
+    c.env.ETCD_INITIAL_CLUSTER = initialClusterStr;
+    c.env.ETCD_INITIAL_CLUSTER_STATE = 'new';
+    c.env.ETCD_ADVERTISE_CLIENT_URLS = `http://${host}:2379`;
+    /* eslint-enable no-param-reassign */
   });
 
   // Used by the cluster members to communicate with each other.

--- a/etcd.js
+++ b/etcd.js
@@ -3,7 +3,10 @@ const { Container, allowTraffic } = require('kelda');
 function Etcd(n) {
   this.containers = [];
   for (let i = 0; i < n; i += 1) {
-    this.containers.push(new Container('etcd', 'quay.io/coreos/etcd:v3.3'));
+    this.containers.push(new Container({
+      name: 'etcd',
+      image: 'quay.io/coreos/etcd:v3.3',
+    }));
   }
 
   const initialCluster = this.containers.map((c) => {

--- a/etcdExample.js
+++ b/etcdExample.js
@@ -4,7 +4,10 @@ const etcd = require('./etcd.js');
 const nWorker = 3;
 
 const baseMachine = new Machine({ provider: 'Amazon' });
-const infra = new Infrastructure(baseMachine, baseMachine.replicate(nWorker));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(nWorker),
+});
 
 const etcdApp = new etcd.Etcd(nWorker);
 etcdApp.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.